### PR TITLE
exclude password reset events

### DIFF
--- a/src/main/java/de/terrestris/keycloak/providers/events/shogun/ShogunEventListenerProviderFactory.java
+++ b/src/main/java/de/terrestris/keycloak/providers/events/shogun/ShogunEventListenerProviderFactory.java
@@ -39,7 +39,8 @@ public class ShogunEventListenerProviderFactory implements EventListenerProvider
 
     private Set<EventType> eventBlacklist = new HashSet<>(Arrays.asList(
             EventType.LOGIN,
-            EventType.LOGOUT
+            EventType.LOGOUT,
+            EventType.SEND_RESET_PASSWORD
     ));
     private Set<OperationType> excludedAdminOperations;
 


### PR DESCRIPTION
For `SEND_RESET_PASSWORD` the event listener currently throws errors. The request body seems to be incomplete.

I think this event is not needed and can be excluded. Can you confirm that @simonseyock @KaiVolland?

@terrestris/devs Please review