### PR TITLE
Allow list of webhook URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,17 @@
 A Keycloak SPI that publishes events to the SHOGun Webhook.
 A (largely) adaptation of https://github.com/jessylenne/keycloak-event-listener-http SPI
 
+# Requirements
+
+Due to old versions of WildFly this requires Java 8 or 11.
+
 # Build
 
-If working in a project environment: Use the environment variable `SHOGUN_WEBHOOK_URI` to configure the webhook uri. Use `INTERCEPTOR_WEBHOOK_URI` to configure an additional webhook for shogun-gs-interceptor.
+If working in a project environment: Use the environment variable `SHOGUN_WEBHOOK_URIS` to configure a list of webhook URIs. Multiple entries have to be separated by `;`, e.g.:
+
+```
+http://progemis-app:8080/webhooks/keycloak;http://progemis-interceptor:8080/webhooks/keycloak
+```
 
 ```
 mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <groupId>org.softwarefactory.keycloak.providers.events.http</groupId>


### PR DESCRIPTION
## Breaking change

This allows to notify multiple services.

Migration: 

- `SHOGUN_WEBHOOK_URI` changed to `SHOGUN_WEBHOOK_URIS` and can be a list of strings, separated by a semicolon (`;`)
- `INTERCEPTOR_WEBHOOK_URI` is not supported anymore