### PR TITLE
Enable token authentication

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ indent_size = 4
 charset = utf-8
 
 # XML config files
-[*.xml]
+[{*.xml,*.md}]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+charset = utf-8

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Keycloak Event Listener SHOGun
 
-A Keycloak Service Provider Interface (SPI) implementation listening to a selection of Keycloak events (all events except 
-`EventType.LOGIN`, `EventType.LOGOUT` and `EventType.SEND_RESET_PASSWORD`) and notifying a SHOGun instance 
-about it via the appropriate [Webhook](https://github.com/terrestris/shogun/blob/main/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java).
+A Keycloak Service Provider Interface (SPI) implementation listening to a selection of Keycloak events and notifying
+a SHOGun instance about it via the appropriate [webhook](https://github.com/terrestris/shogun/blob/main/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java).
 
 A (largely) adaptation of https://github.com/jessylenne/keycloak-event-listener-http SPI.
 
 ## Compatibility
 
-Currently, the extension has been tested against Keycloak version 21, but it should also work with older versions.
+Currently, the extension has been tested against Keycloak version 25, but it should also work with older (and
+probably newer) versions.
 
 ## Development
 
@@ -34,7 +34,7 @@ mvn clean package
 Copy the `target/event-listener-shogun-jar-with-dependencies.jar` (available after it has been built) file to your
 `{KEYCLOAK_HOME}/providers` directory.
 
-If you are working in a [Docker environment](https://quay.io/repository/keycloak/keycloak) you might want to mount 
+If you are working in a [Docker environment](https://quay.io/repository/keycloak/keycloak) you might want to mount
 the `/opt/keycloak/providers` folder as a volume and copy the target to the host directory instead, e.g.:
 
 ```yaml
@@ -46,14 +46,114 @@ volumes:
 
 ### Configuration
 
-By default, the plugin expects a single SHOGun instance running at `http://shogun-boot:8080/`. This path can be adjusted
-if the instance is available at a different host (e.g. `http://my-shogun-boot:8080/`) and/or if multiple instances of
-SHOGun should be notified, e.g. in a clustered environment.
-If needed, set the environment variable `SHOGUN_WEBHOOK_URIS` to your host(s), multiple entries can be separated by `;`:
+The plugin can be configured using a set of environment variables:
 
-```
-SHOGUN_WEBHOOK_URIS=http://http://my-shogun-boot:8080/webhooks/keycloak;http://http://my-shogun-interceptor:8080/webhooks/keycloak
-```
+<table>
+  <tr>
+    <th>Environment Variable</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        SHOGUN_WEBHOOK_EVENT_TYPES
+      </code>
+    </td>
+    <td>
+      A comma-separated list of user event types to listen to. See
+      <a href="https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/events/EventType.java">here</a>
+      for a list of available types.
+    </td>
+    <td>
+      <code>
+        -
+      </code>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        SHOGUN_WEBHOOK_OPERATION_TYPES
+      </code>
+    </td>
+    <td>
+      A comma-separated list of admin operation types to listen to. See
+      <a href="https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/events/admin/OperationType.java">here</a>
+      for a list of available types.
+    </td>
+    <td>
+      <code>
+        CREATE,DELETE
+      </code>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        SHOGUN_WEBHOOK_RESOURCE_TYPES
+      </code>
+    </td>
+    <td>
+      A comma-separated list of admin resource types to listen to. See
+      <a href="https://github.com/keycloak/keycloak/blob/main/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java">here</a>
+      for a list of available types.
+    </td>
+    <td>
+      <code>
+        USER,GROUP,GROUP_MEMBERSHIP
+      </code>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        SHOGUN_WEBHOOK_URIS
+      </code>
+    </td>
+    <td>
+      A comma-separated list of SHOGun webhook URIs to notify. By default, the plugin expects a single SHOGun
+      instance running at <code>http://shogun-boot:8080/webhooks/keycloak</code>. This path can be adjusted if the
+      instance is available at a different host (e.g. <code>http://my-shogun-boot:8080/webhooks/keycloak</code>) and/or
+      if multiple instances of SHOGun should be notified, e.g. in a clustered environment.
+   </td>
+    <td>
+        <code>
+          http://shogun-boot:8080/webhooks/keycloak
+        </code>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        SHOGUN_WEBHOOK_CLIENT_ID
+      </code>
+    </td>
+    <td>
+      The client ID to use for the SHOGun webhook.
+    </td>
+    <td>
+      <code>
+        shogun-boot
+      </code>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        SHOGUN_WEBHOOK_USE_AUTH
+      </code>
+    </td>
+    <td>
+      Whether to use authentication for the webhook or not.
+    </td>
+    <td>
+      <code>
+        true
+      </code>
+    </td>
+  </tr>
+</table>
 
 ### Registration in Keycloak
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>de.terrestris.keycloak.providers.events.shogun</groupId>
   <artifactId>event-listener-shogun</artifactId>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
   <packaging>jar</packaging>
 
   <name>Keycloak: Event Publisher to SHOGun webhook</name>
@@ -38,7 +38,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
 
-    <keycloak.version>21.1.2</keycloak.version>
+    <keycloak.version>25.0.6</keycloak.version>
     <httpclient.version>4.5.14</httpclient.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>


### PR DESCRIPTION
**BREAKING CHANGE**

The previous implementation of the plugin assumes that the webhook in SHOGun is accessible without any authentication. Since the request to the webhook is not equipped with any authentication we used the `IpAddressMatcher` in SHOGun for detecting if a request was sent from the internal Keycloak container (this plugin is running in) to bypass further security checks. Since Spring Security 6.3.1 the [matcher](https://github.com/spring-projects/spring-security/blob/6.3.1/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java) is not accepting a host name anymore (and I'm not quite sure if it was intended to be used before) and any call to the webhook from this plugin is rejected.

This MR suggests to actually send a token to the webhook URL instead of accessing it anonymously. 

In addition it updates the keycloak dependency to version 25 and updates the configuration options from _blacklisting_ the events to _whitelisting_ them. See the README for the newly introduced environment variables.

New requirements for the `shogun-boot` Keycloak client:

- client must allow authentication (= no public client).
  - `Settings` -> `Capability config` -> `Client authentication` -> `On`
- client requires a secret set.
  -  `Credentials` -> `Client Secret`
- client must contain a service account.
  - `Service account roles` -> Add admin role (usually role `admin` from `shogun-boot` client)

Migration summary:

- Build the latest version of the plugin (see the README on how to build it).
- Copy the plugin in your setup (usually something [like this](https://github.com/terrestris/shogun-docker/blob/main/common-services.yml#L55)).
- Set the environment variables as needed (see the README for available ones).
- Adjust the `shogun-boot` (or equivalent in your setup) client in Keycloak as stated above.

Please review @terrestris/devs.